### PR TITLE
Feature url filter

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -120,11 +120,11 @@ export interface Interceptor {
 
 _Description_: This is generic type of interceptor - which is a plain old JavaScript function.  
 You will be dealing with specific one to satisfy it's criteria:
-* `Interceptor<any[], any[]>` - for **request** interceptors
+* `Interceptor<any[], any[]>` - for **request** interceptors  
     Function will get an array of parameters with which call on `Http`
     was made + method name as string (`get`, `post`, `delete`...)
     and should return array of the same structure or `false` to cancel request.
-* `Interceptor<Observable<Response>, Observable<Response>>` - for **response** interceptors
+* `Interceptor<Observable<Response>, Observable<Response>>` - for **response** interceptors  
     Function will get Observable + method name as string (`get`, `post`, `delete`...)
     and should return same or new Observable but with type Response
     (this is made specifically to prevent other code being broken

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,17 @@
-# ng2-http-interceptor [![Build Status](https://travis-ci.org/gund/ng2-http-interceptor.svg?branch=master)](https://travis-ci.org/gund/ng2-http-interceptor) [![codecov](https://codecov.io/gh/gund/ng2-http-interceptor/branch/master/graph/badge.svg)](https://codecov.io/gh/gund/ng2-http-interceptor) [![npm version](https://badge.fury.io/js/ng2-http-interceptor.svg)](https://badge.fury.io/js/ng2-http-interceptor)
+# ng2-http-interceptor
+
+[![Build Status][travis-badge]][travis-badge-url]
+[![Coverage Status][codecov-badge]][codecov-badge-url]
+[![Npm][npm-badge]][npm-badge-url]
 
 > Http Interceptor library for Angular 2
+
+## Table of Contents
+
+* [Installation](#installation)
+* [Usage](#usage)
+* [Documentation](#documentation)
+* [Development](#development)
 
 ## Installation
 
@@ -60,6 +71,65 @@ from one of registered _request_ interceptors.
 You can find in-depth explanation of internal concepts here: https://goo.gl/GU9VWo  
 Also if you want to play with it check this [repo](https://github.com/gund/angular2-http-interceptor-test).
 
+## Documentation
+
+All and every interception setup is made by `HttpInterceptorService` service.  
+Inject this service in place where you want to manage interceptors.
+  
+### Public API
+
+**HttpInterceptorService**
+```ts
+HttpInterceptorService: {
+    request(url?: string|RegExp): Interceptable,
+    response(url?: string|RegExp): Interceptable
+}
+```
+
+<sub>See [src/http/http-interceptor.ts](./src/http/http-interceptor.ts#L8) for full reference</sub>
+
+_Description_: Methods will determine when to call interceptor - before
+request (`request()`) or after response (`response()`).  
+You can also specify url filtering (`string|RegExp`) which will indicate
+when interceptor must be triggered depending on url.  
+By default all interceptors fall under `'/'` url key which means every
+interceptor registered that way will be triggered despite of actual url.
+
+**Interceptable**
+```ts
+Interceptable: {
+    addInterceptor(interceptorFn: Interceptor): Interceptable,
+    removeInterceptor(interceptorFn: Interceptor): Interceptable,
+    clearInterceptors(interceptorFns?: Interceptor[]): Interceptable
+}
+```
+
+<sub>See [src/http/interceptable.ts](./src/http/interceptable.ts#L1) for full reference</sub>
+
+_Description_: This object will help you manage interceptors with
+respect to your selected configuration (url filtering).
+
+**Interceptor**
+```ts
+export interface Interceptor {
+  (data: any, method: string): any;
+}
+```
+
+<sub>See [src/http/interceptable.ts](./src/http/interceptable.ts#L7) for full reference</sub>
+
+_Description_: This is generic type of interceptor - which is a plain old JavaScript function.  
+You will be dealing with specific one to satisfy it's criteria:
+* `Interceptor<any[], any[]>` - for **request** interceptors
+    Function will get an array of parameters with which call on `Http`
+    was made + method name as string (`get`, `post`, `delete`...)
+    and should return array of the same structure or `false` to cancel request.
+* `Interceptor<Observable<Response>, Observable<Response>>` - for **response** interceptors
+    Function will get Observable + method name as string (`get`, `post`, `delete`...)
+    and should return same or new Observable but with type Response
+    (this is made specifically to prevent other code being broken
+    because response was intercepted and structure changed)
+
 ## Development
 
 To generate all `*.js`, `*.js.map` and `*.d.ts` files:
@@ -83,3 +153,11 @@ $ npm test
 ## License
 
 MIT © [Alex Malkevich](malkevich.alex@gmail.com)
+
+
+[travis-badge]: https://travis-ci.org/gund/ng2-http-interceptor.svg?branch=master
+[travis-badge-url]: https://travis-ci.org/gund/ng2-http-interceptor
+[codecov-badge]: https://codecov.io/gh/gund/ng2-http-interceptor/branch/master/graph/badge.svg
+[codecov-badge-url]: https://codecov.io/gh/gund/ng2-http-interceptor
+[npm-badge]: https://badge.fury.io/js/ng2-http-interceptor.svg
+[npm-badge-url]: https://badge.fury.io/js/ng2-http-interceptor

--- a/src/http/http-interceptor.service.spec.ts
+++ b/src/http/http-interceptor.service.spec.ts
@@ -64,9 +64,9 @@ describe('Service: HttpInterceptor', () => {
       expect(store.setActiveStore).toHaveBeenCalledWith('/url');
     });
 
-    it('should call setActiveStore() with provided RegExp converted to string', () => {
+    it('should call setActiveStore() with provided RegExp', () => {
       const store = service.request(/\/my-url/);
-      expect(store.setActiveStore).toHaveBeenCalledWith('/\\/my-url/');
+      expect(store.setActiveStore).toHaveBeenCalledWith(/\/my-url/);
     });
   });
 
@@ -85,9 +85,9 @@ describe('Service: HttpInterceptor', () => {
       expect(store.setActiveStore).toHaveBeenCalledWith('/url');
     });
 
-    it('should call setActiveStore() with provided RegExp converted to string', () => {
+    it('should call setActiveStore() with provided RegExp', () => {
       const store = service.response(/\/my-url/);
-      expect(store.setActiveStore).toHaveBeenCalledWith('/\\/my-url/');
+      expect(store.setActiveStore).toHaveBeenCalledWith(/\/my-url/);
     });
   });
 

--- a/src/http/http-interceptor.service.spec.ts
+++ b/src/http/http-interceptor.service.spec.ts
@@ -101,7 +101,7 @@ describe('Service: HttpInterceptor', () => {
 
       store.getMatchedStores.and.returnValue([fn1, fn2, fn3]);
 
-      const res = service._interceptRequest(method, ['/url']);
+      const res = service._interceptRequest('/url', method, ['/url']);
 
       expect(store.getMatchedStores).toHaveBeenCalledWith('/url');
       expect(fn1).toHaveBeenCalledWith(['/url'], method);
@@ -119,7 +119,7 @@ describe('Service: HttpInterceptor', () => {
 
       store.getMatchedStores.and.returnValue([fn1, fn2, fn3]);
 
-      const res = service._interceptRequest(method, ['/url']);
+      const res = service._interceptRequest('/url', method, ['/url']);
 
       expect(store.getMatchedStores).toHaveBeenCalledWith('/url');
       expect(fn1).toHaveBeenCalledWith(['/url'], method);

--- a/src/http/http-interceptor.service.ts
+++ b/src/http/http-interceptor.service.ts
@@ -15,11 +15,11 @@ export class HttpInterceptorService implements HttpInterceptor {
   }
 
   request(url: string|RegExp = DEFAULT_URL_STORE): Interceptable<RequestInterceptor> {
-    return this._requestStore.setActiveStore(String(url));
+    return this._requestStore.setActiveStore(url);
   }
 
   response(url: string|RegExp = DEFAULT_URL_STORE): Interceptable<ResponseInterceptor> {
-    return this._responseStore.setActiveStore(String(url));
+    return this._responseStore.setActiveStore(url);
   }
 
   _interceptRequest(method: string, data: any[]): any[] {

--- a/src/http/http-interceptor.service.ts
+++ b/src/http/http-interceptor.service.ts
@@ -22,8 +22,8 @@ export class HttpInterceptorService implements HttpInterceptor {
     return this._responseStore.setActiveStore(url);
   }
 
-  _interceptRequest(method: string, data: any[]): any[] {
-    return this._requestStore.getMatchedStores(data[0]).reduce((d, i) => {
+  _interceptRequest(url: string, method: string, data: any[]): any[] {
+    return this._requestStore.getMatchedStores(url).reduce((d, i) => {
       if (!d) {
         return d;
       }

--- a/src/http/http-interceptor.service.ts
+++ b/src/http/http-interceptor.service.ts
@@ -1,33 +1,29 @@
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, RequestInterceptor, ResponseInterceptor } from './http-interceptor';
 import { Interceptable } from './interceptable';
-import { InterceptableStoreFactory } from './interceptable-store';
+import { InterceptableStoreFactory, DEFAULT_URL_STORE } from './interceptable-store';
 import { Observable } from 'rxjs';
 import { Response } from '@angular/http';
 
 @Injectable()
 export class HttpInterceptorService implements HttpInterceptor {
 
-  private _requestInterceptors: RequestInterceptor[] = [];
-  private _responseInterceptors: ResponseInterceptor[] = [];
-  private _requestStore;
-  private _responseStore;
+  private _requestStore = this.store.createStore<RequestInterceptor>();
+  private _responseStore = this.store.createStore<ResponseInterceptor>();
 
-  constructor(store: InterceptableStoreFactory) {
-    this._requestStore = store.createStore<RequestInterceptor>(this._requestInterceptors);
-    this._responseStore = store.createStore<ResponseInterceptor>(this._responseInterceptors);
+  constructor(private store: InterceptableStoreFactory) {
   }
 
-  request(): Interceptable<RequestInterceptor> {
-    return this._requestStore;
+  request(url: string|RegExp = DEFAULT_URL_STORE): Interceptable<RequestInterceptor> {
+    return this._requestStore.setActiveStore(String(url));
   }
 
-  response(): Interceptable<ResponseInterceptor> {
-    return this._responseStore;
+  response(url: string|RegExp = DEFAULT_URL_STORE): Interceptable<ResponseInterceptor> {
+    return this._responseStore.setActiveStore(String(url));
   }
 
   _interceptRequest(method: string, data: any[]): any[] {
-    return this._requestInterceptors.reduce((d, i) => {
+    return this._requestStore.getMatchedStores(data[0]).reduce((d, i) => {
       if (!d) {
         return d;
       }
@@ -36,8 +32,9 @@ export class HttpInterceptorService implements HttpInterceptor {
     }, data);
   }
 
-  _interceptResponse(method: string, response: Observable<Response>): Observable<Response> {
-    return this._responseInterceptors.reduce((o, i) => o.flatMap(_ => i(o, method)), response);
+  _interceptResponse(url: string, method: string, response: Observable<Response>): Observable<Response> {
+    return this._responseStore.getMatchedStores(url)
+      .reduce((o, i) => o.flatMap(_ => i(o, method)), response);
   }
 
 }

--- a/src/http/http-interceptor.ts
+++ b/src/http/http-interceptor.ts
@@ -10,7 +10,7 @@ export interface HttpInterceptor {
   response(url?: string|RegExp): Interceptable<ResponseInterceptor>;
 
   /** @private*/
-  _interceptRequest(method: string, data: any[]): any[];
+  _interceptRequest(url: string, method: string, data: any[]): any[];
   /** @private */
   _interceptResponse(url: string, method: string, response: Observable<Response>): Observable<Response>;
 }

--- a/src/http/http-interceptor.ts
+++ b/src/http/http-interceptor.ts
@@ -6,11 +6,11 @@ export type RequestInterceptor = Interceptor<any[], any[]>;
 export type ResponseInterceptor = Interceptor<Observable<Response>, Observable<Response>>;
 
 export interface HttpInterceptor {
-  request(): Interceptable<RequestInterceptor>;
-  response(): Interceptable<ResponseInterceptor>;
+  request(url?: string|RegExp): Interceptable<RequestInterceptor>;
+  response(url?: string|RegExp): Interceptable<ResponseInterceptor>;
 
   /** @private*/
   _interceptRequest(method: string, data: any[]): any[];
   /** @private */
-  _interceptResponse(method: string, response: Observable<Response>): Observable<Response>;
+  _interceptResponse(url: string, method: string, response: Observable<Response>): Observable<Response>;
 }

--- a/src/http/interceptable-http-proxy.service.spec.ts
+++ b/src/http/interceptable-http-proxy.service.spec.ts
@@ -44,7 +44,7 @@ describe('Service: InterceptableHttpProxy', () => {
       service.get(null, 'testMethod', null);
       const res = service.apply(null, null, ['url']);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['url']);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url']);
       expect(HttpMock.testMethod).toHaveBeenCalledWith('url modified');
       expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod', 'response');
       expect(res).toBe('response modified');
@@ -56,9 +56,18 @@ describe('Service: InterceptableHttpProxy', () => {
       service.get(null, 'testMethod', null);
       const res = service.apply(null, null, ['url']);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['url']);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url']);
       expect(HttpMock.testMethod).not.toHaveBeenCalled();
       expect(res).toEqual(Observable.empty());
+    });
+
+    it('should call _interceptRequest() with Request and correctly extract url', () => {
+      HttpInterceptorServiceMock._interceptRequest.and.returnValue(false);
+
+      service.get(null, 'testMethod', null);
+      service.apply(null, null, [{url: 'url'}]);
+
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', [{url: 'url'}]);
     });
   });
 });

--- a/src/http/interceptable-http-proxy.service.spec.ts
+++ b/src/http/interceptable-http-proxy.service.spec.ts
@@ -38,15 +38,15 @@ describe('Service: InterceptableHttpProxy', () => {
   describe('apply() method', () => {
     it('should call _interceptRequest() on service and method on Http and _interceptResponse on service', () => {
       HttpMock.testMethod.and.returnValue('response');
-      HttpInterceptorServiceMock._interceptRequest.and.returnValue(['data modified']);
+      HttpInterceptorServiceMock._interceptRequest.and.returnValue(['url modified']);
       HttpInterceptorServiceMock._interceptResponse.and.returnValue('response modified');
 
       service.get(null, 'testMethod', null);
-      const res = service.apply(null, null, ['data']);
+      const res = service.apply(null, null, ['url']);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['data']);
-      expect(HttpMock.testMethod).toHaveBeenCalledWith('data modified');
-      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('testMethod', 'response');
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['url']);
+      expect(HttpMock.testMethod).toHaveBeenCalledWith('url modified');
+      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod', 'response');
       expect(res).toBe('response modified');
     });
 
@@ -54,9 +54,9 @@ describe('Service: InterceptableHttpProxy', () => {
       HttpInterceptorServiceMock._interceptRequest.and.returnValue(false);
 
       service.get(null, 'testMethod', null);
-      const res = service.apply(null, null, ['data']);
+      const res = service.apply(null, null, ['url']);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['data']);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('testMethod', ['url']);
       expect(HttpMock.testMethod).not.toHaveBeenCalled();
       expect(res).toEqual(Observable.empty());
     });

--- a/src/http/interceptable-http-proxy.service.ts
+++ b/src/http/interceptable-http-proxy.service.ts
@@ -28,7 +28,7 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
 
     const response = this.http[method].apply(this.http, args);
 
-    return this.httpInterceptorService._interceptResponse(method, response);
+    return this.httpInterceptorService._interceptResponse(args[0], method, response);
   }
 }
 

--- a/src/http/interceptable-http-proxy.service.ts
+++ b/src/http/interceptable-http-proxy.service.ts
@@ -3,11 +3,17 @@ import { Http, XHRBackend, RequestOptions } from '@angular/http';
 import { HttpInterceptorService } from './http-interceptor.service';
 import { Observable } from 'rxjs';
 import { identityFactory } from './util';
+import { isObject } from 'util';
 
 @Injectable()
 export class InterceptableHttpProxyService implements ProxyHandler<any> {
 
   private static _callStack: string[] = [];
+
+  private static _extractUrl(url: any[]): string {
+    const dirtyUrl: string&{url: string} = url[0];
+    return isObject(dirtyUrl) && 'url' in dirtyUrl ? dirtyUrl.url : dirtyUrl;
+  }
 
   constructor(private http: Http, private httpInterceptorService: HttpInterceptorService) {
   }
@@ -19,7 +25,8 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
 
   apply(target: any, thisArg: any, argArray?: any): any {
     const method = InterceptableHttpProxyService._callStack.pop();
-    const args = this.httpInterceptorService._interceptRequest(method, argArray);
+
+    const args = this.httpInterceptorService._interceptRequest(InterceptableHttpProxyService._extractUrl(argArray), method, argArray);
 
     // Check for request cancellation
     if (!args) {
@@ -28,7 +35,7 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
 
     const response = this.http[method].apply(this.http, args);
 
-    return this.httpInterceptorService._interceptResponse(args[0], method, response);
+    return this.httpInterceptorService._interceptResponse(InterceptableHttpProxyService._extractUrl(args), method, response);
   }
 }
 

--- a/src/http/interceptable-store.spec.ts
+++ b/src/http/interceptable-store.spec.ts
@@ -3,72 +3,72 @@
 import { InterceptableStore, InterceptableStoreFactory } from './interceptable-store';
 
 describe('InterceptableStore', () => {
-  let mockStore: any[];
-
-  beforeEach(() => mockStore = []);
-
   it('should create an instance', () => {
-    expect(new InterceptableStore<any>(mockStore)).toBeTruthy();
+    expect(new InterceptableStore<any>()).toBeTruthy();
   });
 
   describe('addInterceptor() method', () => {
-    it('should add item to store and return self', () => {
-      const store = new InterceptableStore<any>(mockStore);
+    it('should add item to default store and return self', () => {
+      const store = new InterceptableStore<any>();
 
       expect(store.addInterceptor(5)).toBe(store);
-      expect(mockStore.length).toBe(1);
-      expect(mockStore[0]).toBe(5);
+      expect(store.getStore().length).toBe(1);
+      expect(store.getStore()[0]).toBe(5);
     });
   });
 
   describe('removeInterceptor() method', () => {
-    it('should remove item from store and return self', () => {
-      mockStore = [1, 2, 3];
-      const store = new InterceptableStore<any>(mockStore);
+    it('should remove item from default store and return self', () => {
+      const store = new InterceptableStore<any>();
+      store.getStore().push(1);
+      store.getStore().push(2);
+      store.getStore().push(3);
 
       expect(store.removeInterceptor(2)).toBe(store);
-      expect(mockStore).toEqual([1, 3]);
+      expect(store.getStore()).toEqual([1, 3]);
     });
 
     it('should do nothing if item not found and return self', () => {
-      mockStore = [1, 2, 3];
-      const store = new InterceptableStore<any>(mockStore);
+      const store = new InterceptableStore<any>();
+      store.getStore().push(1);
+      store.getStore().push(2);
+      store.getStore().push(3);
 
       expect(store.removeInterceptor(4)).toBe(store);
-      expect(mockStore).toEqual([1, 2, 3]);
+      expect(store.getStore()).toEqual([1, 2, 3]);
     });
   });
 
   describe('clearInterceptors() method', () => {
-    it('should clear store and return self', () => {
-      mockStore = [1, 2, 3];
-      const store = new InterceptableStore<any>(mockStore);
+    it('should clear default store and return self', () => {
+      const store = new InterceptableStore<any>();
+      store.getStore().push(1);
+      store.getStore().push(2);
+      store.getStore().push(3);
 
       expect(store.clearInterceptors()).toBe(store);
-      expect(mockStore).toEqual([]);
+      expect(store.getStore()).toEqual([]);
     });
 
     it('should invoke removeInterceptor() for every item in arg and return self', () => {
-      mockStore = [1, 2, 3];
-      const store = new InterceptableStore<any>(mockStore);
+      const store = new InterceptableStore<any>();
       spyOn(store, 'removeInterceptor').and.callThrough();
+      store.getStore().push(1);
+      store.getStore().push(2);
+      store.getStore().push(3);
 
       expect(store.clearInterceptors([1, 3])).toBe(store);
       expect(store.removeInterceptor).toHaveBeenCalledTimes(2);
-      expect(mockStore).toEqual([2]);
+      expect(store.getStore()).toEqual([2]);
     });
   });
 
   describe('InterceptableStoreFactory', () => {
     describe('createStore() method', () => {
-      it('should create new InterceptableStore with store provided', () => {
+      it('should create new InterceptableStore', () => {
         const storeFactory = new InterceptableStoreFactory();
-        const store = storeFactory.createStore<any>(mockStore);
-
+        const store = storeFactory.createStore<any>();
         expect(store).toEqual(jasmine.any(InterceptableStore));
-
-        store.addInterceptor(1);
-        expect(mockStore).toEqual([1]);
       });
     });
   });

--- a/src/http/interceptable-store.spec.ts
+++ b/src/http/interceptable-store.spec.ts
@@ -1,25 +1,34 @@
-/* tslint:disable:no-unused-variable */
-
 import { InterceptableStore, InterceptableStoreFactory } from './interceptable-store';
+import Spy = jasmine.Spy;
 
 describe('InterceptableStore', () => {
+  let store: InterceptableStore<any>;
+
+  beforeEach(() => store = new InterceptableStore<any>());
+
   it('should create an instance', () => {
-    expect(new InterceptableStore<any>()).toBeTruthy();
+    expect(store).toBeTruthy();
   });
 
   describe('addInterceptor() method', () => {
     it('should add item to default store and return self', () => {
-      const store = new InterceptableStore<any>();
-
       expect(store.addInterceptor(5)).toBe(store);
       expect(store.getStore().length).toBe(1);
       expect(store.getStore()[0]).toBe(5);
+    });
+
+    it('should add item to two different stores', () => {
+      store.setActiveStore('store1').addInterceptor(1);
+      store.setActiveStore('store2').addInterceptor(2);
+
+      expect(store.getStore('store1')).toEqual([1]);
+      expect(store.getStore('store2')).toEqual([2]);
+      expect(store.getStore().length).toBe(0);
     });
   });
 
   describe('removeInterceptor() method', () => {
     it('should remove item from default store and return self', () => {
-      const store = new InterceptableStore<any>();
       store.getStore().push(1);
       store.getStore().push(2);
       store.getStore().push(3);
@@ -29,7 +38,6 @@ describe('InterceptableStore', () => {
     });
 
     it('should do nothing if item not found and return self', () => {
-      const store = new InterceptableStore<any>();
       store.getStore().push(1);
       store.getStore().push(2);
       store.getStore().push(3);
@@ -37,11 +45,21 @@ describe('InterceptableStore', () => {
       expect(store.removeInterceptor(4)).toBe(store);
       expect(store.getStore()).toEqual([1, 2, 3]);
     });
+
+    it('should remove item from two different stores', () => {
+      store.setActiveStore('store1').addInterceptor(1).addInterceptor(2).addInterceptor(3);
+      store.setActiveStore('store2').addInterceptor(4).addInterceptor(5).addInterceptor(6);
+
+      expect(store.setActiveStore('store1').removeInterceptor(2)).toBe(store);
+      expect(store.getStore('store1')).toEqual([1, 3]);
+
+      expect(store.setActiveStore('store2').removeInterceptor(5)).toBe(store);
+      expect(store.getStore('store2')).toEqual([4, 6]);
+    });
   });
 
   describe('clearInterceptors() method', () => {
     it('should clear default store and return self', () => {
-      const store = new InterceptableStore<any>();
       store.getStore().push(1);
       store.getStore().push(2);
       store.getStore().push(3);
@@ -51,7 +69,6 @@ describe('InterceptableStore', () => {
     });
 
     it('should invoke removeInterceptor() for every item in arg and return self', () => {
-      const store = new InterceptableStore<any>();
       spyOn(store, 'removeInterceptor').and.callThrough();
       store.getStore().push(1);
       store.getStore().push(2);
@@ -61,15 +78,100 @@ describe('InterceptableStore', () => {
       expect(store.removeInterceptor).toHaveBeenCalledTimes(2);
       expect(store.getStore()).toEqual([2]);
     });
+
+    it('should clear two different stores', () => {
+      store.setActiveStore('store1').addInterceptor(1).addInterceptor(2).addInterceptor(3);
+      store.setActiveStore('store2').addInterceptor(4).addInterceptor(5).addInterceptor(6);
+
+      expect(store.setActiveStore('store1').clearInterceptors()).toBe(store);
+      expect(store.getStore('store1')).toEqual([]);
+      expect(store.getStore('store2')).toEqual([4, 5, 6]); // Still exists
+
+      expect(store.setActiveStore('store2').clearInterceptors()).toBe(store);
+      expect(store.getStore('store2')).toEqual([]);
+    });
+
+    it('should invoke removeInterceptor() for every item in arg for active store', () => {
+      spyOn(store, 'removeInterceptor').and.callThrough();
+      store.setActiveStore('store1').addInterceptor(1).addInterceptor(2).addInterceptor(3);
+      store.setActiveStore('store2').addInterceptor(4).addInterceptor(5).addInterceptor(6);
+
+      expect(store.setActiveStore('store1').clearInterceptors([1, 3])).toBe(store);
+      expect(store.removeInterceptor).toHaveBeenCalledTimes(2);
+      expect(store.getStore('store1')).toEqual([2]);
+      expect(store.getStore('store2')).toEqual([4, 5, 6]); // Still exists
+
+      (<Spy>store.removeInterceptor).calls.reset();
+      expect(store.setActiveStore('store2').clearInterceptors([4, 6])).toBe(store);
+      expect(store.removeInterceptor).toHaveBeenCalledTimes(2);
+      expect(store.getStore('store2')).toEqual([5]);
+    });
   });
 
-  describe('InterceptableStoreFactory', () => {
-    describe('createStore() method', () => {
-      it('should create new InterceptableStore', () => {
-        const storeFactory = new InterceptableStoreFactory();
-        const store = storeFactory.createStore<any>();
-        expect(store).toEqual(jasmine.any(InterceptableStore));
-      });
+  describe('setActiveStore() method', () => {
+    it('should set `activeStore` from arg and return self', () => {
+      expect(store.setActiveStore('key1')).toBe(store);
+      store.addInterceptor(1);
+      expect(store.getStore('key1')).toEqual([1]);
+      expect(store.getStore()).toEqual([]);
+    });
+
+    it('should set `activeStore` by default to `/` and return self', () => {
+      store.setActiveStore('key1').addInterceptor(1);
+      expect(store.setActiveStore()).toBe(store);
+      store.addInterceptor(2);
+
+      expect(store.getStore('key1')).toEqual([1]);
+      expect(store.getStore()).toEqual([2]);
+    });
+  });
+
+  describe('getStore() method', () => {
+    it('should return new store by key', () => {
+      expect(store.getStore('key')).toEqual([]);
+    });
+
+    it('should return by default store with key `/`', () => {
+      store.setActiveStore('/').addInterceptor(1);
+      expect(store.getStore()).toEqual([1]);
+    });
+
+    it('should return already created store by same key', () => {
+      expect(store.getStore('key')).toEqual([]);
+      store.setActiveStore('key').addInterceptor(1);
+      expect(store.getStore('key')).toEqual([1]);
+    });
+  });
+
+  describe('getMatchedStores() method', () => {
+    beforeEach(() => {
+      store.addInterceptor(1);
+      store.setActiveStore('/key1').addInterceptor(2);
+      store.setActiveStore('/key2/val1').addInterceptor(3);
+      store.setActiveStore(/\/key\d+\/?.*/).addInterceptor(4);
+      store.setActiveStore(/\/no-match/).addInterceptor(5);
+      store.setActiveStore(/\/(will-match)?$/).addInterceptor(6);
+    });
+
+    it('should return by default all stores matched by `/` merged', () => {
+      expect(store.getMatchedStores()).toEqual([1, 6]);
+    });
+
+    it('should return stores matched by key merged', () => {
+      expect(store.getMatchedStores('/key2')).toEqual([1, 4]);
+      expect(store.getMatchedStores('/key2/val1')).toEqual([1, 3, 4]);
+      expect(store.getMatchedStores('/key1')).toEqual([1, 2, 4]);
+      expect(store.getMatchedStores('/will-match')).toEqual([1, 6]);
+    });
+  });
+});
+
+describe('InterceptableStoreFactory', () => {
+  describe('createStore() method', () => {
+    it('should create new InterceptableStore', () => {
+      const storeFactory = new InterceptableStoreFactory();
+      const store = storeFactory.createStore<any>();
+      expect(store).toEqual(jasmine.any(InterceptableStore));
     });
   });
 });

--- a/src/http/interceptable-store.ts
+++ b/src/http/interceptable-store.ts
@@ -7,15 +7,22 @@ export type AnyInterceptor = Interceptor<any, any>;
 export class InterceptableStoreFactory {
 
   // noinspection JSMethodCanBeStatic
-  createStore<D extends AnyInterceptor>(store: D[]) {
-    return new InterceptableStore<D>(store);
+  createStore<D extends AnyInterceptor>() {
+    return new InterceptableStore<D>();
   }
 
 }
 
+export const DEFAULT_URL_STORE = '/';
+
 export class InterceptableStore<T extends AnyInterceptor> implements Interceptable<T> {
 
-  constructor(private store: T[] = []) {
+  private storeMatcher: {[url: string]: RegExp} = {};
+  private stores: {[url: string]: T[]} = {};
+  private activeStore: string = DEFAULT_URL_STORE;
+
+  private get store(): T[] {
+    return this._getStoreSafely(this.activeStore);
   }
 
   addInterceptor(interceptor: T): Interceptable<T> {
@@ -42,6 +49,31 @@ export class InterceptableStore<T extends AnyInterceptor> implements Interceptab
     }
 
     return this;
+  }
+
+  // ----------
+  // Internal API
+
+  setActiveStore(url = DEFAULT_URL_STORE): InterceptableStore<T> {
+    this.activeStore = url;
+    this.storeMatcher[url] = new RegExp(url);
+    return this;
+  }
+
+  getStore(key = DEFAULT_URL_STORE): T[] {
+    return this._getStoreSafely(key);
+  }
+
+  getMatchedStores(url = DEFAULT_URL_STORE): T[] {
+    const backedUrl = `/${url.replace('/', '\\/')}/`;
+    return Object.keys(this.stores)
+      .filter(k => k === url || k === backedUrl || this.storeMatcher[k].test(url))
+      .map(k => this.getStore(k))
+      .reduce((stores, store) => [...stores, ...store], []);
+  }
+
+  private _getStoreSafely(key: string): T[] {
+    return (this.stores[key] || (this.stores[key] = []));
   }
 
 }


### PR DESCRIPTION
This PR represents new feature which allows registering interceptors on specific urls.
Updated unit tests and documentation accordingly.
Fully backward compatible with prev public API.