### PR TITLE
use zone.js to add context to share data between interceptors

### DIFF
--- a/src/http/high-level-api.spec.ts
+++ b/src/http/high-level-api.spec.ts
@@ -5,6 +5,8 @@ import { MockBackend } from '@angular/http/testing';
 import { HTTP_INTERCEPTOR_PROVIDER } from './providers';
 import { Observable } from 'rxjs';
 
+declare let Zone;
+
 describe('High-level API', () => {
   let httpInterceptor: HttpInterceptorService;
   let mockBackend: MockBackend;
@@ -69,6 +71,20 @@ describe('High-level API', () => {
       http.get('/').subscribe(callback);
 
       expect(callback).not.toHaveBeenCalled();
+    }));
+
+    it('should be able to share data between interceptors', async(() => {
+      interceptor.and.callFake(d => {
+        Zone.current.get('context')['testkey'] = 'test';
+        return d;
+      });
+      const interceptor1 = jasmine.createSpy('interceptor1');
+      interceptor1.and.callFake(d => {
+        expect(Zone.current.get('context')['testkey']).toBe('test');
+        return d;
+      });
+      httpInterceptor.request().addInterceptor(interceptor1);
+      http.post('/url', 'data').subscribe(() => null);
     }));
   });
 

--- a/src/http/high-level-api.spec.ts
+++ b/src/http/high-level-api.spec.ts
@@ -4,7 +4,7 @@ import { XHRBackend, HttpModule, Http, Response, ResponseOptions } from '@angula
 import { MockBackend } from '@angular/http/testing';
 import { HTTP_INTERCEPTOR_PROVIDER } from './providers';
 import { Observable } from 'rxjs';
-import { getContextFromCurrentZone } from './util';
+import { getContext } from './util';
 
 describe('High-level API', () => {
   let httpInterceptor: HttpInterceptorService;
@@ -74,7 +74,7 @@ describe('High-level API', () => {
 
     it('should be able to share data between interceptors', async(() => {
       interceptor.and.callFake(d => {
-        let context = getContextFromCurrentZone();
+        let context = getContext();
         if (context) {
           context['testkey'] = 'test';
         }
@@ -82,7 +82,7 @@ describe('High-level API', () => {
       });
       const interceptor1 = jasmine.createSpy('interceptor1');
       interceptor1.and.callFake(d => {
-        let context = getContextFromCurrentZone();
+        let context = getContext();
         expect(context).not.toBeNull();
         expect(context['testkey']).toBe('test');
         return d;

--- a/src/http/high-level-api.spec.ts
+++ b/src/http/high-level-api.spec.ts
@@ -4,8 +4,7 @@ import { XHRBackend, HttpModule, Http, Response, ResponseOptions } from '@angula
 import { MockBackend } from '@angular/http/testing';
 import { HTTP_INTERCEPTOR_PROVIDER } from './providers';
 import { Observable } from 'rxjs';
-
-declare let Zone;
+import { getContextFromCurrentZone } from './util';
 
 describe('High-level API', () => {
   let httpInterceptor: HttpInterceptorService;
@@ -75,12 +74,17 @@ describe('High-level API', () => {
 
     it('should be able to share data between interceptors', async(() => {
       interceptor.and.callFake(d => {
-        Zone.current.get('context')['testkey'] = 'test';
+        let context = getContextFromCurrentZone();
+        if (context) {
+          context['testkey'] = 'test';
+        }
         return d;
       });
       const interceptor1 = jasmine.createSpy('interceptor1');
       interceptor1.and.callFake(d => {
-        expect(Zone.current.get('context')['testkey']).toBe('test');
+        let context = getContextFromCurrentZone();
+        expect(context).not.toBeNull();
+        expect(context['testkey']).toBe('test');
         return d;
       });
       httpInterceptor.request().addInterceptor(interceptor1);

--- a/src/http/util.ts
+++ b/src/http/util.ts
@@ -6,6 +6,6 @@ export const identityFactory = (provide, obj) => ({
   deps: [obj]
 });
 
-export function getContextFromCurrentZone() {
+export function getContext() {
   return Zone.current.getZoneWith('context').get('context');
 };

--- a/src/http/util.ts
+++ b/src/http/util.ts
@@ -1,5 +1,15 @@
+declare let Zone;
+
 export const identityFactory = (provide, obj) => ({
   provide,
   useFactory: proxy => proxy,
   deps: [obj]
 });
+
+export function getContextFromCurrentZone() {
+  let zone = Zone.current.getZoneWith('context');
+  if (zone) {
+    return zone.get('context');
+  }
+  return null;
+};

--- a/src/http/util.ts
+++ b/src/http/util.ts
@@ -7,9 +7,5 @@ export const identityFactory = (provide, obj) => ({
 });
 
 export function getContextFromCurrentZone() {
-  let zone = Zone.current.getZoneWith('context');
-  if (zone) {
-    return zone.get('context');
-  }
-  return null;
+  return Zone.current.getZoneWith('context').get('context');
 };


### PR DESCRIPTION
Based on #50, add a context to share data between interceptors, to keep the current interface unchange, use a interceptorZone to share data.

to set data in context.

```javascript
    let interceptor = (data, method) => { 
        let context = getContext();
        if (context) context['key'] = 'value';
        return data;
    }

    let otherInterceptor = (data, method) => { 
        let context = getContext();
        if (context) let sharedData = context['key'];
        return data;
    }
```