### PR TITLE
Proxy polyfill fix

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,11 +43,15 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['DebuggableChrome'],
     singleRun: false,
 
     // browser for travis-ci
     customLaunchers: {
+      DebuggableChrome: {
+        base: 'Chrome',
+        flags: ['--remote-debugging-port=9222']
+      },
       Chrome_travis_ci: {
         base: 'Chrome',
         flags: ['--no-sandbox', harmony_flags]

--- a/src/http/high-level-api.spec.ts
+++ b/src/http/high-level-api.spec.ts
@@ -15,7 +15,7 @@ describe('High-level API', () => {
     TestBed.configureTestingModule({
       imports: [HttpModule],
       providers: [
-        {provide: XHRBackend, useClass: MockBackend},
+        { provide: XHRBackend, useClass: MockBackend },
         ...HTTP_INTERCEPTOR_PROVIDER
       ]
     });
@@ -134,7 +134,7 @@ describe('High-level API', () => {
   }
 
   function responseBody(body, status = 200) {
-    return new Response(new ResponseOptions({body, status}));
+    return new Response(new ResponseOptions({ body, status }));
   }
 
 });

--- a/src/http/interceptable-http-proxy.service.ts
+++ b/src/http/interceptable-http-proxy.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Http, XHRBackend, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { HttpInterceptorService } from './http-interceptor.service';
-import { identityFactory } from './util';
+import { identityFactory, safeProxy } from './util';
 import { isObject } from 'util';
 
 @Injectable()
@@ -49,7 +49,7 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
 }
 
 export function _proxyFactory(http, interceptor) {
-  return new Proxy(() => null, new InterceptableHttpProxyService(http, interceptor));
+  return safeProxy(() => null, new InterceptableHttpProxyService(http, interceptor));
 }
 
 export function proxyFactory(backend, options, interceptor) {

--- a/src/http/util.ts
+++ b/src/http/util.ts
@@ -9,3 +9,19 @@ export function identityFactory(provide, obj) {
     deps: [obj]
   };
 }
+
+export const SAFE_PROXY_TRAPS = ['get', 'set', 'apply'];
+
+export function safeProxyHandler_(handler: any, traps: string[]): any {
+  const safeHandler = {};
+
+  traps
+    .filter(trap => typeof handler[trap] === 'function' && traps.indexOf(trap) !== -1)
+    .forEach(trap => safeHandler[trap] = handler[trap].bind(handler));
+
+  return safeHandler;
+}
+
+export function safeProxy(obj: any, handler: any, traps = SAFE_PROXY_TRAPS): any {
+  return new Proxy(obj, safeProxyHandler_(handler, traps));
+}


### PR DESCRIPTION
Allows use of [proxy polyfill library](https://github.com/GoogleChrome/proxy-polyfill).
See issue #41.