### PR TITLE
add context to share data between interceptors

### DIFF
--- a/src/http/high-level-api.spec.ts
+++ b/src/http/high-level-api.spec.ts
@@ -87,7 +87,7 @@ describe('High-level API', () => {
 
       http.get('/').subscribe(callback);
 
-      expect(interceptor).toHaveBeenCalledWith(['/'], 'get');
+      expect(interceptor).toHaveBeenCalledWith(['/'], 'get', jasmine.anything());
       expect(callbackBackend).not.toHaveBeenCalled();
       expect(callback).not.toHaveBeenCalled();
 
@@ -97,6 +97,21 @@ describe('High-level API', () => {
       expect(callbackBackend).toHaveBeenCalled();
       expect(callback).toHaveBeenCalled();
     }));
+
+    it('should be able to share data between interceptors', async(() => {
+      interceptor.and.callFake((d, m, context) => {
+          context['testkey'] = 'test';
+          return d;
+      });
+      const interceptor1 = jasmine.createSpy('interceptor1');
+        interceptor1.and.callFake((d, m, context) => {
+          expect(context).not.toBeNull();
+          expect(context['testkey']).toBe('test');
+          return d;
+        });
+        httpInterceptor.request().addInterceptor(interceptor1);
+        http.post('/url', 'data').subscribe(() => null);
+      }));
   });
 
   describe('response()', () => {
@@ -205,7 +220,7 @@ describe('High-level API', () => {
 
         it('should intercept requests made by InterceptableHttp', async(() => {
           interceptableHttp.get('something').subscribe();
-          expect(interceptor).toHaveBeenCalledWith(['something'], 'get');
+          expect(interceptor).toHaveBeenCalledWith(['something'], 'get', jasmine.anything());
         }));
       });
     });
@@ -229,7 +244,7 @@ describe('High-level API', () => {
 
       http[method](url, data).subscribe(callback); // Request
 
-      expect(interceptor).toHaveBeenCalledWith([url, data], method); // Interceptor called?
+      expect(interceptor).toHaveBeenCalledWith([url, data], method, jasmine.anything()); // Interceptor called?
       expect(callback).toHaveBeenCalled(); // Response callback called?
       expect(connCallback).toHaveBeenCalledTimes(1); // Only one request?
     }));

--- a/src/http/http-interceptor.service.spec.ts
+++ b/src/http/http-interceptor.service.spec.ts
@@ -105,9 +105,9 @@ describe('Service: HttpInterceptor', () => {
       service._interceptRequest('/url', method, ['/url']).subscribe(r => res = r);
 
       expect(store.getMatchedStores).toHaveBeenCalledWith('/url');
-      expect(fn1).toHaveBeenCalledWith(['/url'], method);
-      expect(fn2).toHaveBeenCalledWith(['/url1'], method);
-      expect(fn3).toHaveBeenCalledWith(['/url2'], method);
+      expect(fn1).toHaveBeenCalledWith(['/url'], method, undefined);
+      expect(fn2).toHaveBeenCalledWith(['/url1'], method, undefined);
+      expect(fn3).toHaveBeenCalledWith(['/url2'], method, undefined);
       expect(res).toEqual(['/url3']);
     }));
 
@@ -124,8 +124,8 @@ describe('Service: HttpInterceptor', () => {
       service._interceptRequest('/url', method, ['/url']).subscribe(r => res = r);
 
       expect(store.getMatchedStores).toHaveBeenCalledWith('/url');
-      expect(fn1).toHaveBeenCalledWith(['/url'], method);
-      expect(fn2).toHaveBeenCalledWith(['/url1'], method);
+      expect(fn1).toHaveBeenCalledWith(['/url'], method, undefined);
+      expect(fn2).toHaveBeenCalledWith(['/url1'], method, undefined);
       expect(fn3).not.toHaveBeenCalled();
       expect(res).toBeFalsy();
     }));
@@ -153,9 +153,9 @@ describe('Service: HttpInterceptor', () => {
       const res = service._interceptResponse('/url', method, <any>observableMock);
 
       expect(store.getMatchedStores).toHaveBeenCalledWith('/url');
-      expect(fn1).toHaveBeenCalledWith(observableMock, method);
-      expect(fn2).toHaveBeenCalledWith(observableMock, method);
-      expect(fn3).toHaveBeenCalledWith(observableMock, method);
+      expect(fn1).toHaveBeenCalledWith(observableMock, method, undefined);
+      expect(fn2).toHaveBeenCalledWith(observableMock, method, undefined);
+      expect(fn3).toHaveBeenCalledWith(observableMock, method, undefined);
       expect(res).toBe('changed observable');
     });
   });

--- a/src/http/http-interceptor.service.ts
+++ b/src/http/http-interceptor.service.ts
@@ -26,20 +26,20 @@ export class HttpInterceptorService implements HttpInterceptor {
     return this._responseStore.setActiveStore(url);
   }
 
-  _interceptRequest(url: string, method: string, data: any[]): Observable<any[]> {
+  _interceptRequest(url: string, method: string, data: any[], context?: any): Observable<any[]> {
     return this._requestStore.getMatchedStores(url).reduce(
       (o, i) => o.flatMap(d => {
         if (!d) {
           return Observable.of(d);
         }
-        return HttpInterceptorService.wrapInObservable(i(d, method));
+        return HttpInterceptorService.wrapInObservable(i(d, method, context));
       }),
       Observable.of(data)
     );
   }
 
-  _interceptResponse(url: string, method: string, response: Observable<Response>): Observable<Response> {
-    return this._responseStore.getMatchedStores(url).reduce((o, i) => i(o, method), response);
+  _interceptResponse(url: string, method: string, response: Observable<Response>, context?: any): Observable<Response> {
+    return this._responseStore.getMatchedStores(url).reduce((o, i) => i(o, method, context), response);
   }
 
 }

--- a/src/http/interceptable-http-proxy.service.spec.ts
+++ b/src/http/interceptable-http-proxy.service.spec.ts
@@ -56,7 +56,7 @@ describe('Service: InterceptableHttpProxy', () => {
       service.get(null, 'testMethod', null);
       service.apply(null, null, ['url']).subscribe();
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url']);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url'], jasmine.anything());
       expect(HttpMock.testMethod).toHaveBeenCalledWith('url modified');
     }));
 
@@ -67,7 +67,7 @@ describe('Service: InterceptableHttpProxy', () => {
       service.get(null, 'testMethod', null);
       service.apply(null, null, ['url']).subscribe(callback);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url']);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', ['url'], jasmine.anything());
       expect(HttpMock.testMethod).not.toHaveBeenCalled();
       expect(callback).not.toHaveBeenCalled();
     }));
@@ -78,7 +78,7 @@ describe('Service: InterceptableHttpProxy', () => {
       service.get(null, 'testMethod', null);
       service.apply(null, null, [{ url: 'url' }]);
 
-      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', [{ url: 'url' }]);
+      expect(HttpInterceptorServiceMock._interceptRequest).toHaveBeenCalledWith('url', 'testMethod', [{ url: 'url' }], jasmine.anything());
     });
 
     it('should call .flatMap() on success, call _interceptRequest() inside and return result', () => {
@@ -94,7 +94,8 @@ describe('Service: InterceptableHttpProxy', () => {
 
       // This check is no longer valid since observable shared internally
       // expect(observable.flatMap).toHaveBeenCalledWith(jasmine.any(Function)); // Normal branch!
-      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod', jasmine.any(Observable));
+      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod',
+        jasmine.any(Observable), jasmine.anything());
       expect(callback).toHaveBeenCalledWith('modified response');
     });
 
@@ -115,7 +116,8 @@ describe('Service: InterceptableHttpProxy', () => {
 
       // This check is no longer valid since observable shared internally
       // expect(observable.catch).toHaveBeenCalledWith(jasmine.any(Function)); // Catch branch!
-      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod', jasmine.any(Observable));
+      expect(HttpInterceptorServiceMock._interceptResponse).toHaveBeenCalledWith('url modified', 'testMethod',
+        jasmine.any(Observable), jasmine.anything());
       expect(callback).toHaveBeenCalledWith('modified response');
     }));
   });

--- a/src/http/interceptable-http-proxy.service.ts
+++ b/src/http/interceptable-http-proxy.service.ts
@@ -25,8 +25,11 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
   apply(target: any, thisArg: any, argArray?: any): any {
     const method = InterceptableHttpProxyService._callStack.pop();
 
+    // create a object without prototype as the context object
+    const context = Object.create(null);
+
     return this.httpInterceptorService
-      ._interceptRequest(InterceptableHttpProxyService._extractUrl(argArray), method, argArray)
+      ._interceptRequest(InterceptableHttpProxyService._extractUrl(argArray), method, argArray, context)
       .switchMap(args => {
         // Check for request cancellation
         if (!args) {
@@ -38,14 +41,14 @@ export class InterceptableHttpProxyService implements ProxyHandler<any> {
           .refCount();
 
         return response
-          .flatMap(this._responseCall(args, method, response))
-          .catch(this._responseCall(args, method, response));
+          .flatMap(this._responseCall(args, method, response, context))
+          .catch(this._responseCall(args, method, response, context));
       });
   }
 
-  private _responseCall(args, method, response) {
+  private _responseCall(args, method, response, context) {
     return () => this.httpInterceptorService._interceptResponse(
-      InterceptableHttpProxyService._extractUrl(args), method, response);
+      InterceptableHttpProxyService._extractUrl(args), method, response, context);
   }
 }
 

--- a/src/http/interceptable.ts
+++ b/src/http/interceptable.ts
@@ -5,5 +5,5 @@ export interface Interceptable<T extends Interceptor<any, any>> {
 }
 
 export interface Interceptor<T, D> {
-  (data: T, method: string): D;
+  (data: T, method: string, ctx?: any): D;
 }


### PR DESCRIPTION
Based on #50, add a context to share data between interceptors, to keep the current interface unchange, use a interceptorZone to share data.

to set data in context.
```javascript
  let interceptor = (data, method, context) => { 
        if (context) context['key'] = 'value';
        return data;
    }

    let otherInterceptor = (data, method, context) => { 
        if (context) let sharedData = context['key'];
        return data;
    }
```